### PR TITLE
Fix TypeError: Struct() argument 1 must be string, not unicode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix issue where encoding and decoding of statusmessages into cookie
+  raised exception, because of
+  ``TypeError: Struct() argument 1 must be string, not unicode``
+  [datakurre]
 
 
 5.0 (2017-08-04)

--- a/Products/statusmessages/message.py
+++ b/Products/statusmessages/message.py
@@ -82,7 +82,7 @@ class Message:
         size = (len(message) << 5) + (len(type) & 31)  # pack into 16 bits
 
         return struct.pack(
-            '!H{0}s{1}s'.format(len(message), len(type)),
+            b'!H{0}s{1}s'.format(len(message), len(type)),
             size,
             message,
             type,
@@ -99,7 +99,7 @@ def decode(value):
     We expect at least 2 bytes (size information).
     """
     if len(value) >= 2:
-        size = struct.unpack('!H', value[:2])[0]
+        size = struct.unpack(b'!H', value[:2])[0]
         msize, tsize = (size >> 5, size & 31)
         message = Message(
             _unicode(value[2:msize+2]),


### PR DESCRIPTION
The error was due to ``from __future__ import unicode_literals`` in ``messages.py`` and was fixed by using ``b''`` literals. Yet, I wonder, why this only failed on our RHEL7 production servers using RHEL python.